### PR TITLE
Bug Fix: Support serverless.yml with no custom block

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,7 +240,8 @@ Object.defineProperties(
 			return this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 		}),
 		pluginConfig: d(function () {
-			let pluginConfig = this.serverless.service.custom.dynamodbAutoscaling;
+			let custom = this.serverless.service.custom || {};
+			let pluginConfig = custom.dynamodbAutoscaling;
 			if (!isValue(pluginConfig)) return { tablesConfig: {}, chainScalingPolicies: true };
 			if (!isObject(pluginConfig)) {
 				throw new Error(


### PR DESCRIPTION
If no custom section is defined the plugin will fail because `this.serverless.service.custom` is undefined and thus has no `dynamodbAutoscaling` property.