### PR TITLE
Add option to use predefined IAM role

### DIFF
--- a/test/__snapshots__/resources-no-indexes-iam-role.js
+++ b/test/__snapshots__/resources-no-indexes-iam-role.js
@@ -1,0 +1,84 @@
+"use strict";
+
+module.exports = {
+	EnterpriseBookingsReadScalableTarget: {
+		Type: "AWS::ApplicationAutoScaling::ScalableTarget",
+		Properties: {
+			MaxCapacity: 200,
+			MinCapacity: 5,
+			ResourceId: {
+				"Fn::Join": [
+					"/",
+					[
+						"table",
+						{
+							Ref: "EnterpriseBookings"
+						}
+					]
+				]
+			},
+			RoleARN: "autoscaling-role-arn",
+			ScalableDimension: "dynamodb:table:ReadCapacityUnits",
+			ServiceNamespace: "dynamodb"
+		}
+	},
+	EnterpriseBookingsReadScalingPolicy: {
+		Type: "AWS::ApplicationAutoScaling::ScalingPolicy",
+		DependsOn: undefined,
+		Properties: {
+			PolicyName: "ReadAutoScalingPolicy",
+			PolicyType: "TargetTrackingScaling",
+			ScalingTargetId: {
+				Ref: "EnterpriseBookingsReadScalableTarget"
+			},
+			TargetTrackingScalingPolicyConfiguration: {
+				TargetValue: 75,
+				ScaleInCooldown: 60,
+				ScaleOutCooldown: 60,
+				PredefinedMetricSpecification: {
+					PredefinedMetricType: "DynamoDBReadCapacityUtilization"
+				}
+			}
+		}
+	},
+	EnterpriseBookingsWriteScalableTarget: {
+		Type: "AWS::ApplicationAutoScaling::ScalableTarget",
+		Properties: {
+			MaxCapacity: 200,
+			MinCapacity: 5,
+			ResourceId: {
+				"Fn::Join": [
+					"/",
+					[
+						"table",
+						{
+							Ref: "EnterpriseBookings"
+						}
+					]
+				]
+			},
+			RoleARN: "autoscaling-role-arn",
+			ScalableDimension: "dynamodb:table:WriteCapacityUnits",
+			ServiceNamespace: "dynamodb"
+		}
+	},
+	EnterpriseBookingsWriteScalingPolicy: {
+		Type: "AWS::ApplicationAutoScaling::ScalingPolicy",
+		DependsOn: "EnterpriseBookingsReadScalingPolicy",
+		Properties: {
+			PolicyName: "WriteAutoScalingPolicy",
+			PolicyType: "TargetTrackingScaling",
+			ScalingTargetId: {
+				Ref: "EnterpriseBookingsWriteScalableTarget"
+			},
+			TargetTrackingScalingPolicyConfiguration: {
+				TargetValue: 75,
+				ScaleInCooldown: 60,
+				ScaleOutCooldown: 60,
+				PredefinedMetricSpecification: {
+					PredefinedMetricType: "DynamoDBWriteCapacityUtilization"
+				}
+			}
+		}
+	}
+};

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,7 @@ const roleResource                = require("./__snapshots__/role-resource")
     , tableIndexes                = require("./__snapshots__/table-indexes")
     , resourcesNoIndexes          = require("./__snapshots__/resources-no-indexes-default")
     , resourcesNoIndexesLambdaIam = require("./__snapshots__/resources-no-indexes-lambda-iam")
+    , resourcesNoIndexesIAMRole   = require("./__snapshots__/resources-no-indexes-iam-role")
     , resourcesIndexes            = require("./__snapshots__/resources-indexes-default")
     , resourcesIndexesNoChaining  = require("./__snapshots__/resources-indexes-no-chaining")
     , resourcesIndexesNoIndexes   = require("./__snapshots__/resources-indexes-no-indexes")
@@ -220,6 +221,16 @@ test("Serverless Plugin Dynamodb Autoscaling", t => {
 		templateMock.Resources,
 		Object.assign({}, roleResource, tableNoIndexes),
 		"Do not add autoscaling resources with iamOnly option"
+	);
+
+	plugin = new Plugin(serverlessMock);
+	templateMock.Resources = Object.assign({}, tableNoIndexes);
+	configMock.dynamodbAutoscaling = { iamRole: "autoscaling-role-arn" };
+	plugin.configure();
+	t.deepEqual(
+		templateMock.Resources,
+		Object.assign({}, tableNoIndexes, resourcesNoIndexesIAMRole),
+		"Do not add iam resources with iamRole option"
 	);
 
 	plugin = new Plugin(serverlessMock);


### PR DESCRIPTION
I added the option to use 
```
dynamodbAutoscaling:
  iamRole: 'use-some-iam-role-arn-here'
```
to use a predefined role. This option takes precedence before added a new `DynamodbAutoscalingRole` role or adding permissions to the `IamRoleLambdaExecution` role.

I like that this plugin takes care of all the CF resources I need to configure DynamoDB autoscaling, but in my company we don't configure IAM permission once we deploy features to the staging and production environment. We have a different process and sometimes different people to manage them.

I added this option to be able to separate the the cloud formation autoscaling configuration from the IAM permission management. It gives the user more control of how specific or general his autoscaling policy is defined.