### PR TITLE
Support Cloudformation substituted table names

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,40 +44,39 @@ resources:
     Table2:
       Properties:
         TableName: tableName2
-    ...
-    Table7:
+    Table3:
       Properties:
         TableName: 
           Fn::Sub: ${AWS::Region}-table
 custom:
   dynamodbAutoscaling:
     tablesConfig:
-      # Disable autoscaling for tableName1 table entirely
-      tableName1: false
+      # Disable autoscaling for Table1 table entirely
+      Table1: false
 
-      # Disable autoscaling just for indexes of tableName2 table
-      tableName2:
+      # Disable autoscaling just for indexes of Table2 table
+      Table2:
         indexes: false
 
-      # Tweak minCapacity setting for all tables that start with tableName
+      # Tweak minCapacity setting for all tables that start with Table
       # (glob patterns can be used)
-      tableName*:
+      Table*:
         minCapacity: 10
 
-      tableName4:
-        # Tweak maxCapacity setting for tableName4 (just table)
+      Table4:
+        # Tweak maxCapacity setting for Table4 (just table)
         table:
           maxCapacity: 300
-        # Tweak targetUsage setting for tableName4 indexes
+        # Tweak targetUsage setting for Table4 indexes
         indexes:
           targetUsage: 0.5
 
-      tableName5:
+      Table5:
         indexes:
           # Do not autoscale index 'foo'
           foo: false
 
-      tableName6:
+      Table6:
         indexes:
           # Do not autoscale any indexes but 'foo' and 'bar'
           "*": false
@@ -85,10 +84,6 @@ custom:
           bar:
             # Tweaking one of the configuration option will also whitelist the index
             minCapacity: 100
-      
-      # Table names created with Cloudformation params can be referenced by Resource name
-      Table7:
-        minCapacity: 10
 ```
 
 ###### White list approach
@@ -102,8 +97,8 @@ custom:
       # Disable autoscaling for all
       "*": false
 
-      # but enable for tableName1
-      tableName1: true
+      # but enable for Table1
+      Table1: true
 ```
 
 ##### Configurable settings:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ By default autoscaling configuration is automatically applied to all preconfigur
 Still, we can exclude individual tables or tweak their configuration via configuration within`serverless.yml` config:
 
 ```yaml
+resources:
+  Resources:
+    Table1:
+      Properties:
+        TableName: tableName1
+    Table2:
+      Properties:
+        TableName: tableName2
+    ...
+    Table7:
+      Properties:
+        TableName: 
+          Fn::Sub: ${AWS::Region}-table
 custom:
   dynamodbAutoscaling:
     tablesConfig:
@@ -72,6 +85,10 @@ custom:
           bar:
             # Tweaking one of the configuration option will also whitelist the index
             minCapacity: 100
+      
+      # Table names created with Cloudformation params can be referenced by Resource name
+      Table7:
+        minCapacity: 10
 ```
 
 ###### White list approach

--- a/index.js
+++ b/index.js
@@ -269,14 +269,11 @@ Object.defineProperties(
 				.map(resourceName => {
 					const resource = this.resources[resourceName];
 					if (resource.Type !== "AWS::DynamoDB::Table") return null;
-					const tableName = isObject(resource.Properties.TableName)
-						? resourceName
-						: resource.Properties.TableName;
 					const configList = compact.call(
 						objToArray(
 							resolvedPluginConfig,
 							(config, pattern) =>
-								minimatch(tableName, pattern)
+								minimatch(resourceName, pattern)
 									? copyDeep(config)
 									: null
 						)

--- a/index.js
+++ b/index.js
@@ -269,7 +269,9 @@ Object.defineProperties(
 				.map(resourceName => {
 					const resource = this.resources[resourceName];
 					if (resource.Type !== "AWS::DynamoDB::Table") return null;
-					const tableName = isObject(resource.Properties.TableName) ? resourceName : resource.Properties.TableName;
+					const tableName = isObject(resource.Properties.TableName)
+						? resourceName
+						: resource.Properties.TableName;
 					const configList = compact.call(
 						objToArray(
 							resolvedPluginConfig,

--- a/index.js
+++ b/index.js
@@ -269,11 +269,12 @@ Object.defineProperties(
 				.map(resourceName => {
 					const resource = this.resources[resourceName];
 					if (resource.Type !== "AWS::DynamoDB::Table") return null;
+					const tableName = isObject(resource.Properties.TableName) ? resourceName : resource.Properties.TableName;
 					const configList = compact.call(
 						objToArray(
 							resolvedPluginConfig,
 							(config, pattern) =>
-								minimatch(resource.Properties.TableName, pattern)
+								minimatch(tableName, pattern)
 									? copyDeep(config)
 									: null
 						)

--- a/test/__snapshots__/resources-indexes-dynamic-table-name.js
+++ b/test/__snapshots__/resources-indexes-dynamic-table-name.js
@@ -2,87 +2,87 @@
 
 module.exports = {
     DynamicTableReadScalableTarget: {
-      Type: 'AWS::ApplicationAutoScaling::ScalableTarget',
+      Type: "AWS::ApplicationAutoScaling::ScalableTarget",
       Properties: {
         MaxCapacity: 5,
         MinCapacity: 5,
         ResourceId: {
-          'Fn::Join': [
-            '/',
+          "Fn::Join": [
+            "/",
             [
-              'table',
+              "table",
               {
-                Ref: 'DynamicTable'
+                Ref: "DynamicTable"
               }
             ]
           ]
         },
         RoleARN: {
-          'Fn::GetAtt': 'DynamodbAutoscalingRole.Arn'
+          "Fn::GetAtt": "DynamodbAutoscalingRole.Arn"
         },
-        ScalableDimension: 'dynamodb:table:ReadCapacityUnits',
-        ServiceNamespace: 'dynamodb'
+        ScalableDimension: "dynamodb:table:ReadCapacityUnits",
+        ServiceNamespace: "dynamodb"
       }
     },
     DynamicTableReadScalingPolicy: {
-      Type: 'AWS::ApplicationAutoScaling::ScalingPolicy',
+      Type: "AWS::ApplicationAutoScaling::ScalingPolicy",
       DependsOn: undefined,
       Properties: {
-        PolicyName: 'ReadAutoScalingPolicy',
-        PolicyType: 'TargetTrackingScaling',
+        PolicyName: "ReadAutoScalingPolicy",
+        PolicyType: "TargetTrackingScaling",
         ScalingTargetId: {
-          Ref: 'DynamicTableReadScalableTarget'
+          Ref: "DynamicTableReadScalableTarget"
         },
         TargetTrackingScalingPolicyConfiguration: {
           TargetValue: 75,
           ScaleInCooldown: 60,
           ScaleOutCooldown: 60,
           PredefinedMetricSpecification: {
-            PredefinedMetricType: 'DynamoDBReadCapacityUtilization'
+            PredefinedMetricType: "DynamoDBReadCapacityUtilization"
           }
         }
       }
     },
     DynamicTableWriteScalableTarget: {
-      Type: 'AWS::ApplicationAutoScaling::ScalableTarget',
+      Type: "AWS::ApplicationAutoScaling::ScalableTarget",
       Properties: {
         MaxCapacity: 5,
         MinCapacity: 5,
         ResourceId: {
-          'Fn::Join': [
-            '/',
+          "Fn::Join": [
+            "/",
             [
-              'table',
+              "table",
               {
-                Ref: 'DynamicTable'
+                Ref: "DynamicTable"
               }
             ]
           ]
         },
         RoleARN: {
-          'Fn::GetAtt': 'DynamodbAutoscalingRole.Arn'
+          "Fn::GetAtt": "DynamodbAutoscalingRole.Arn"
         },
-        ScalableDimension: 'dynamodb:table:WriteCapacityUnits',
-        ServiceNamespace: 'dynamodb'
+        ScalableDimension: "dynamodb:table:WriteCapacityUnits",
+        ServiceNamespace: "dynamodb"
       }
     },
     DynamicTableWriteScalingPolicy: {
-      Type: 'AWS::ApplicationAutoScaling::ScalingPolicy',
-      DependsOn: 'DynamicTableReadScalingPolicy',
+      Type: "AWS::ApplicationAutoScaling::ScalingPolicy",
+      DependsOn: "DynamicTableReadScalingPolicy",
       Properties: {
-        PolicyName: 'WriteAutoScalingPolicy',
-        PolicyType: 'TargetTrackingScaling',
+        PolicyName: "WriteAutoScalingPolicy",
+        PolicyType: "TargetTrackingScaling",
         ScalingTargetId: {
-          Ref: 'DynamicTableWriteScalableTarget'
+          Ref: "DynamicTableWriteScalableTarget"
         },
         TargetTrackingScalingPolicyConfiguration: {
           TargetValue: 75,
           ScaleInCooldown: 60,
           ScaleOutCooldown: 60,
           PredefinedMetricSpecification: {
-            PredefinedMetricType: 'DynamoDBWriteCapacityUtilization'
+            PredefinedMetricType: "DynamoDBWriteCapacityUtilization"
           }
         }
       }
     }
-  }
+  };

--- a/test/__snapshots__/resources-indexes-dynamic-table-name.js
+++ b/test/__snapshots__/resources-indexes-dynamic-table-name.js
@@ -1,0 +1,88 @@
+"use strict";
+
+module.exports = {
+    DynamicTableReadScalableTarget: {
+      Type: 'AWS::ApplicationAutoScaling::ScalableTarget',
+      Properties: {
+        MaxCapacity: 5,
+        MinCapacity: 5,
+        ResourceId: {
+          'Fn::Join': [
+            '/',
+            [
+              'table',
+              {
+                Ref: 'DynamicTable'
+              }
+            ]
+          ]
+        },
+        RoleARN: {
+          'Fn::GetAtt': 'DynamodbAutoscalingRole.Arn'
+        },
+        ScalableDimension: 'dynamodb:table:ReadCapacityUnits',
+        ServiceNamespace: 'dynamodb'
+      }
+    },
+    DynamicTableReadScalingPolicy: {
+      Type: 'AWS::ApplicationAutoScaling::ScalingPolicy',
+      DependsOn: undefined,
+      Properties: {
+        PolicyName: 'ReadAutoScalingPolicy',
+        PolicyType: 'TargetTrackingScaling',
+        ScalingTargetId: {
+          Ref: 'DynamicTableReadScalableTarget'
+        },
+        TargetTrackingScalingPolicyConfiguration: {
+          TargetValue: 75,
+          ScaleInCooldown: 60,
+          ScaleOutCooldown: 60,
+          PredefinedMetricSpecification: {
+            PredefinedMetricType: 'DynamoDBReadCapacityUtilization'
+          }
+        }
+      }
+    },
+    DynamicTableWriteScalableTarget: {
+      Type: 'AWS::ApplicationAutoScaling::ScalableTarget',
+      Properties: {
+        MaxCapacity: 5,
+        MinCapacity: 5,
+        ResourceId: {
+          'Fn::Join': [
+            '/',
+            [
+              'table',
+              {
+                Ref: 'DynamicTable'
+              }
+            ]
+          ]
+        },
+        RoleARN: {
+          'Fn::GetAtt': 'DynamodbAutoscalingRole.Arn'
+        },
+        ScalableDimension: 'dynamodb:table:WriteCapacityUnits',
+        ServiceNamespace: 'dynamodb'
+      }
+    },
+    DynamicTableWriteScalingPolicy: {
+      Type: 'AWS::ApplicationAutoScaling::ScalingPolicy',
+      DependsOn: 'DynamicTableReadScalingPolicy',
+      Properties: {
+        PolicyName: 'WriteAutoScalingPolicy',
+        PolicyType: 'TargetTrackingScaling',
+        ScalingTargetId: {
+          Ref: 'DynamicTableWriteScalableTarget'
+        },
+        TargetTrackingScalingPolicyConfiguration: {
+          TargetValue: 75,
+          ScaleInCooldown: 60,
+          ScaleOutCooldown: 60,
+          PredefinedMetricSpecification: {
+            PredefinedMetricType: 'DynamoDBWriteCapacityUtilization'
+          }
+        }
+      }
+    }
+  }

--- a/test/__snapshots__/table-dynamic-name.json
+++ b/test/__snapshots__/table-dynamic-name.json
@@ -1,0 +1,27 @@
+{
+    "DynamicTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "id",
+            "AttributeType": "S"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "id",
+            "KeyType": "HASH"
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 1,
+          "WriteCapacityUnits": 1
+        },
+        "TableName": {
+            "Fn::Sub": "${AWS::Region}-table"
+        }
+      }
+    }
+  }
+  

--- a/test/index.js
+++ b/test/index.js
@@ -118,8 +118,8 @@ test("Serverless Plugin Dynamodb Autoscaling", t => {
 	templateMock.Resources = Object.assign({}, tableIndexes);
 	configMock.dynamodbAutoscaling = {
 		tablesConfig: {
-			"maas-tsp-dev-nextbike-customers": { table: { maxCapacity: 800 } },
-			"elo": { minCapactity: 30 }
+			NextbikeCustomers: { table: { maxCapacity: 800 } },
+			elo: { minCapacity: 30 }
 		}
 	};
 	plugin.configure();

--- a/test/index.js
+++ b/test/index.js
@@ -128,12 +128,12 @@ test("Serverless Plugin Dynamodb Autoscaling", t => {
 		Object.assign({}, roleResource, tableIndexes, resourcesIndexesCustom2),
 		"Apply specific table custom settings"
     );
-    
+
 	plugin = new Plugin(serverlessMock);
 	templateMock.Resources = Object.assign({}, tableDynamicName);
 	configMock.dynamodbAutoscaling = {
 		tablesConfig: {
-			"DynamicTable": { table: { maxCapacity: 5 } }
+			DynamicTable: { table: { maxCapacity: 5 } }
 		}
 	};
 	plugin.configure();
@@ -142,7 +142,7 @@ test("Serverless Plugin Dynamodb Autoscaling", t => {
 		Object.assign({}, tableDynamicName, roleResource, resourcesDynamicTablename),
 		"Apply table specific settings to Fn::Sub tablename"
 	);
-    
+
 	plugin = new Plugin(serverlessMock);
 	templateMock.Resources = Object.assign({}, tableIndexes);
 	configMock.dynamodbAutoscaling = { tablesConfig: { "*": { indexes: true } } };

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ const roleResource                = require("./__snapshots__/role-resource")
     , lambdaRoleResourcePatched2  = require("./__snapshots__/lambda-role-resource-patched-2")
     , tableNoIndexes              = require("./__snapshots__/table-no-indexes")
     , tableIndexes                = require("./__snapshots__/table-indexes")
+    , tableDynamicName            = require("./__snapshots__/table-dynamic-name")
     , resourcesNoIndexes          = require("./__snapshots__/resources-no-indexes-default")
     , resourcesNoIndexesLambdaIam = require("./__snapshots__/resources-no-indexes-lambda-iam")
     , resourcesNoIndexesIAMRole   = require("./__snapshots__/resources-no-indexes-iam-role")
@@ -19,7 +20,8 @@ const roleResource                = require("./__snapshots__/role-resource")
     , resourcesIndexesNoIndexes   = require("./__snapshots__/resources-indexes-no-indexes")
     , resourcesIndexesNoTable     = require("./__snapshots__/resources-indexes-no-table")
     , resourcesIndexesCustom      = require("./__snapshots__/resources-indexes-custom")
-    , resourcesIndexesCustom2     = require("./__snapshots__/resources-indexes-custom-2");
+    , resourcesIndexesCustom2     = require("./__snapshots__/resources-indexes-custom-2")
+    , resourcesDynamicTablename   = require("./__snapshots__/resources-indexes-dynamic-table-name");
 
 test("Serverless Plugin Dynamodb Autoscaling", t => {
 	const templateMock = {}, configMock = {};
@@ -125,8 +127,22 @@ test("Serverless Plugin Dynamodb Autoscaling", t => {
 		templateMock.Resources,
 		Object.assign({}, roleResource, tableIndexes, resourcesIndexesCustom2),
 		"Apply specific table custom settings"
+    );
+    
+	plugin = new Plugin(serverlessMock);
+	templateMock.Resources = Object.assign({}, tableDynamicName);
+	configMock.dynamodbAutoscaling = {
+		tablesConfig: {
+			"DynamicTable": { table: { maxCapacity: 5 } }
+		}
+	};
+	plugin.configure();
+	t.deepEqual(
+		templateMock.Resources,
+		Object.assign({}, tableDynamicName, roleResource, resourcesDynamicTablename),
+		"Apply table specific settings to Fn::Sub tablename"
 	);
-
+    
 	plugin = new Plugin(serverlessMock);
 	templateMock.Resources = Object.assign({}, tableIndexes);
 	configMock.dynamodbAutoscaling = { tablesConfig: { "*": { indexes: true } } };


### PR DESCRIPTION
I'm trying to setup an auto-scaled Dynamo table, and running into issues getting this plugin to work with table names computed using Cloudformation substitutions. It works just fine with the appropriate refs when no table is specified in `custom`, but when the table is specified everything breaks down, as the TableName is an object in this case.

This PR simply uses the resource name as the table name when the specified TableName is an object.

@medikoo 