### PR TITLE
Fix behavior when generated IAM role is overridden in Resources

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,30 +303,32 @@ Object.defineProperties(
 				: "DynamodbAutoscalingRole";
 		}),
 		iamRoleResource: d(function () {
-			return (
-				this.resources[this.iamRoleResourceId] ||
-				(this.resources[this.iamRoleResourceId] = {
-					Type: "AWS::IAM::Role",
-					Properties: {
-						AssumeRolePolicyDocument: {
-							Version: "2012-10-17",
-							Statement: [
-								{
-									Effect: "Allow",
-									Principal: { Service: [] },
-									Action: ["sts:AssumeRole"]
-								}
-							]
-						},
-						Path: "/",
-						Policies: [
+			const defaultRole = {
+				Type: "AWS::IAM::Role",
+				Properties: {
+					AssumeRolePolicyDocument: {
+						Version: "2012-10-17",
+						Statement: [
 							{
-								PolicyName: "root",
-								PolicyDocument: { Version: "2012-10-17", Statement: [] }
+								Effect: "Allow",
+								Principal: { Service: [] },
+								Action: ["sts:AssumeRole"]
 							}
 						]
-					}
-				})
+					},
+					Path: "/",
+					Policies: [
+						{
+							PolicyName: "root",
+							PolicyDocument: { Version: "2012-10-17", Statement: [] }
+						}
+					]
+				}
+			};
+			return (this.resources[this.iamRoleResourceId] =
+				this.resources.IamRoleLambdaExecution
+					? this.resources[this.iamRoleResourceId]
+					: assignDeep({}, defaultRole, this.resources[this.iamRoleResourceId] || {})
 			);
 		})
 	})

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const copyDeep = require("es5-ext/object/copy-deep")
+const assignDeep = require("es5-ext/object/assign-deep")
+    , copyDeep = require("es5-ext/object/copy-deep")
     , test     = require("tape")
     , Plugin   = require("../");
 
@@ -34,6 +35,24 @@ test("Serverless Plugin Dynamodb Autoscaling", t => {
 	t.deepEqual(
 		templateMock.Resources, Object.assign({}, roleResource, tableNoIndexes, resourcesNoIndexes),
 		"Automatically creates scaling resources for a table"
+	);
+	serverlessMock.service.custom = configMock;
+
+	plugin = new Plugin(serverlessMock);
+	const resourceOverride = {
+		DynamodbAutoscalingRole: {
+			Properties: {
+				RoleName: "NextbikeCustomersAutoscalingRole"
+			}
+		}
+	};
+	templateMock.Resources = Object.assign({}, tableNoIndexes, resourceOverride);
+	delete serverlessMock.service.custom;
+	plugin.configure();
+	t.deepEqual(
+		templateMock.Resources,
+		assignDeep({}, roleResource, tableNoIndexes, resourcesNoIndexes, resourceOverride),
+		"Respects resource overrides when creating scaling resources for a table"
 	);
 	serverlessMock.service.custom = configMock;
 


### PR DESCRIPTION
In the current state, an exception is thrown during packaging when an IAM role is generated for the autoscaling policy, and the role has an overridden attribute specified in Resources. Instead of throwing an exception, the plugin now respects the override.

I encountered this trying to override the RoleName for the generated `DynamodbAutoscalingRole`, which throws a `TypeError` since every other field expected doesn't yet exist